### PR TITLE
Limits

### DIFF
--- a/src/from_stream.rs
+++ b/src/from_stream.rs
@@ -17,6 +17,7 @@ pin_project! {
     pub struct FromStream<S> {
         #[pin]
         stream: S,
+        limit: Option<usize>,
     }
 }
 
@@ -26,6 +27,7 @@ where
     S: Send + Sync,
 {
     FromStream {
+        limit: None,
         stream: stream.into_stream(),
     }
 }
@@ -39,5 +41,14 @@ where
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.project();
         this.stream.poll_next(cx)
+    }
+
+    fn set_limit(mut self, limit: impl Into<Option<usize>>) -> Self {
+        self.limit = limit.into();
+        self
+    }
+
+    fn limit(&self) -> Option<usize> {
+        self.limit
     }
 }

--- a/src/from_stream.rs
+++ b/src/from_stream.rs
@@ -43,12 +43,12 @@ where
         this.stream.poll_next(cx)
     }
 
-    fn set_limit(mut self, limit: impl Into<Option<usize>>) -> Self {
+    fn limit(mut self, limit: impl Into<Option<usize>>) -> Self {
         self.limit = limit.into();
         self
     }
 
-    fn limit(&self) -> Option<usize> {
+    fn get_limit(&self) -> Option<usize> {
         self.limit
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,3 +56,5 @@ pub use par_stream::{ForEach, Map, NextFuture, ParallelStream, Take};
 
 pub mod prelude;
 pub mod vec;
+
+pub(crate) mod utils;

--- a/src/par_stream/for_each.rs
+++ b/src/par_stream/for_each.rs
@@ -19,8 +19,6 @@ pin_project_lite::pin_project! {
         exhausted: Arc<AtomicBool>,
         // Count how many tasks are executing.
         ref_count: Arc<AtomicU64>,
-        // Max concurrency limit.
-        limit: Option<usize>,
     }
 }
 
@@ -35,13 +33,13 @@ impl ForEach {
         let exhausted = Arc::new(AtomicBool::new(false));
         let ref_count = Arc::new(AtomicU64::new(0));
         let (sender, receiver): (Sender<()>, Receiver<()>) = sync::channel(1);
+        let _limit = stream.get_limit();
 
         // Initialize the return type here to prevent borrowing issues.
         let this = Self {
             receiver,
             exhausted: exhausted.clone(),
             ref_count: ref_count.clone(),
-            limit: stream.limit(),
         };
 
         task::spawn(async move {

--- a/src/par_stream/map.rs
+++ b/src/par_stream/map.rs
@@ -14,6 +14,7 @@ pin_project_lite::pin_project! {
     pub struct Map<T> {
         #[pin]
         receiver: Receiver<T>,
+        limit: Option<usize>,
     }
 }
 
@@ -26,6 +27,7 @@ impl<T: Send + 'static> Map<T> {
         Fut: Future<Output = T> + Send,
     {
         let (sender, receiver) = sync::channel(1);
+        let limit = stream.limit();
         task::spawn(async move {
             while let Some(item) = stream.next().await {
                 let sender = sender.clone();
@@ -35,7 +37,7 @@ impl<T: Send + 'static> Map<T> {
                 });
             }
         });
-        Map { receiver }
+        Map { receiver, limit }
     }
 }
 
@@ -45,6 +47,15 @@ impl<T: Send + 'static> ParallelStream for Map<T> {
         use async_std::prelude::*;
         let this = self.project();
         this.receiver.poll_next(cx)
+    }
+
+    fn set_limit(mut self, limit: impl Into<Option<usize>>) -> Self {
+        self.limit = limit.into();
+        self
+    }
+
+    fn limit(&self) -> Option<usize> {
+        self.limit
     }
 }
 

--- a/src/par_stream/map.rs
+++ b/src/par_stream/map.rs
@@ -27,7 +27,7 @@ impl<T: Send + 'static> Map<T> {
         Fut: Future<Output = T> + Send,
     {
         let (sender, receiver) = sync::channel(1);
-        let limit = stream.limit();
+        let limit = stream.get_limit();
         task::spawn(async move {
             while let Some(item) = stream.next().await {
                 let sender = sender.clone();
@@ -49,12 +49,12 @@ impl<T: Send + 'static> ParallelStream for Map<T> {
         this.receiver.poll_next(cx)
     }
 
-    fn set_limit(mut self, limit: impl Into<Option<usize>>) -> Self {
+    fn limit(mut self, limit: impl Into<Option<usize>>) -> Self {
         self.limit = limit.into();
         self
     }
 
-    fn limit(&self) -> Option<usize> {
+    fn get_limit(&self) -> Option<usize> {
         self.limit
     }
 }

--- a/src/par_stream/mod.rs
+++ b/src/par_stream/mod.rs
@@ -22,10 +22,10 @@ pub trait ParallelStream: Sized + Send + Sync + Unpin + 'static {
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>>;
 
     /// Set a max concurrency limit
-    fn set_limit(self, limit: impl Into<Option<usize>>) -> Self;
+    fn limit(self, limit: impl Into<Option<usize>>) -> Self;
 
     /// Get the max concurrency limit
-    fn limit(&self) -> Option<usize>;
+    fn get_limit(&self) -> Option<usize>;
 
     /// Applies `f` to each item of this stream in parallel, producing a new
     /// stream with the results.

--- a/src/par_stream/mod.rs
+++ b/src/par_stream/mod.rs
@@ -21,6 +21,12 @@ pub trait ParallelStream: Sized + Send + Sync + Unpin + 'static {
     /// Attempts to receive the next item from the stream.
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>>;
 
+    /// Set a max concurrency limit
+    fn set_limit(self, limit: impl Into<Option<usize>>) -> Self;
+
+    /// Get the max concurrency limit
+    fn limit(&self) -> Option<usize>;
+
     /// Applies `f` to each item of this stream in parallel, producing a new
     /// stream with the results.
     fn map<F, T, Fut>(self, f: F) -> Map<T>

--- a/src/par_stream/take.rs
+++ b/src/par_stream/take.rs
@@ -17,14 +17,19 @@ pin_project! {
     #[derive(Clone, Debug)]
     pub struct Take<S> {
         #[pin]
-        pub(crate) stream: S,
-        pub(crate) remaining: usize,
+        stream: S,
+        remaining: usize,
+        limit: Option<usize>,
     }
 }
 
-impl<S> Take<S> {
+impl<S: ParallelStream> Take<S> {
     pub(super) fn new(stream: S, remaining: usize) -> Self {
-        Self { stream, remaining }
+        Self {
+            limit: stream.limit(),
+            remaining,
+            stream,
+        }
     }
 }
 
@@ -43,5 +48,14 @@ impl<S: ParallelStream> ParallelStream for Take<S> {
             }
             Poll::Ready(next)
         }
+    }
+
+    fn set_limit(mut self, limit: impl Into<Option<usize>>) -> Self {
+        self.limit = limit.into();
+        self
+    }
+
+    fn limit(&self) -> Option<usize> {
+        self.limit
     }
 }

--- a/src/par_stream/take.rs
+++ b/src/par_stream/take.rs
@@ -26,7 +26,7 @@ pin_project! {
 impl<S: ParallelStream> Take<S> {
     pub(super) fn new(stream: S, remaining: usize) -> Self {
         Self {
-            limit: stream.limit(),
+            limit: stream.get_limit(),
             remaining,
             stream,
         }
@@ -50,12 +50,12 @@ impl<S: ParallelStream> ParallelStream for Take<S> {
         }
     }
 
-    fn set_limit(mut self, limit: impl Into<Option<usize>>) -> Self {
+    fn limit(mut self, limit: impl Into<Option<usize>>) -> Self {
         self.limit = limit.into();
         self
     }
 
-    fn limit(&self) -> Option<usize> {
+    fn get_limit(&self) -> Option<usize> {
         self.limit
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,55 @@
+// use core::pin::Pin;
+// use core::task::{Context, Poll};
+
+// use std::sync::atomic::{AtomicUsize, Ordering};
+// use std::sync::Arc;
+
+// use async_std::stream::Stream;
+
+// /// A stream that has a max concurrency of N.
+// pub(crate) struct LimitStream {
+//     limit: Option<usize>,
+//     ref_count: Arc<AtomicUsize>,
+// }
+
+// impl LimitStream {
+//     /// Create a new instance of LimitStream.
+//     pub(crate) fn new(limit: Option<usize>) -> Self {
+//         Self {
+//             limit,
+//             ref_count: Arc::new(AtomicUsize::new(0)),
+//         }
+//     }
+// }
+
+// #[derive(Debug)]
+// pub(crate) struct Guard {
+//     limit: Option<usize>,
+//     ref_count: Arc<AtomicUsize>,
+// }
+
+// impl Guard {
+//     fn new(limit: Option<usize>, ref_count: Arc<AtomicUsize>) -> Self {
+//         Self { limit, ref_count }
+//     }
+// }
+
+// impl Drop for Guard {
+//     fn drop(&mut self) {
+//         if self.limit.is_some() {
+//             self.ref_count.fetch_sub(1, Ordering::SeqCst);
+//         }
+//     }
+// }
+
+// impl Stream for LimitStream {
+//     type Item = Guard;
+
+//     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+//         if self.limit.is_none() {
+//             let guard = Guard::new(self.limit, self.ref_count.clone());
+//             return Poll::Ready(Some(guard));
+//         }
+//         todo!();
+//     }
+// }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -28,12 +28,12 @@ impl<T: Send + Sync + 'static> ParallelStream for IntoParStream<T> {
         this.stream.poll_next(cx)
     }
 
-    fn set_limit(mut self, limit: impl Into<Option<usize>>) -> Self {
+    fn limit(mut self, limit: impl Into<Option<usize>>) -> Self {
         self.limit = limit.into();
         self
     }
 
-    fn limit(&self) -> Option<usize> {
+    fn get_limit(&self) -> Option<usize> {
         self.limit
     }
 }


### PR DESCRIPTION
Initializes the `limit` functionality outlined in #1. This only updates the traits to contain the functionality, and provide the methods. It does not yet *enforce* the limits, however.

The impl on how to enforce it is probably to create a stream wrapper that returns a tuple of `(item, guard)` that increments an internal counter if a limit has been set. Then when the guard is dropped, using an `AtomicWaker` it can wake the stream up to continue polling (while checking capacity).

Either way, this is a required first step to get us forward. Thanks!